### PR TITLE
Migrate utils.py from ipyvega

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,23 +83,40 @@ Or Vega-lite:
 ```python
 from jupyterlab_vega import VegaLite
 
-VegaLite({
-    "data": {
-        "values": [
-            {"a": "A", "b": 28}, {"a": "B", "b": 55}, {"a": "C", "b": 43},
-            {"a": "D", "b": 91}, {"a": "E", "b": 81}, {"a": "F", "b": 53},
-            {"a": "G", "b": 19}, {"a": "H", "b": 87}, {"a": "I", "b": 52}
-        ]
-    },
+spec = {
     "mark": "bar",
     "encoding": {
         "x": {"field": "a", "type": "ordinal"},
         "y": {"field": "b", "type": "quantitative"}
     }
-})
+}
+data = [
+    {"a": "A", "b": 28}, {"a": "B", "b": 55}, {"a": "C", "b": 43},
+    {"a": "D", "b": 91}, {"a": "E", "b": 81}, {"a": "F", "b": 53},
+    {"a": "G", "b": 19}, {"a": "H", "b": 87}, {"a": "I", "b": 52}
+]
+
+VegaLite(spec, data)
 ```
 
-<!-- Using Altair:
+Using a pandas DataFrame:
+
+```python
+from jupyterlab_vega import VegaLite
+import pandas as pd
+
+df = pd.reada_json('cars.json')
+
+VegaLite({
+  "mark": "point",
+  "encoding": {
+    "y": {"type": "quantitative","field": "Acceleration"},
+    "x": {"type": "quantitative","field": "Horsepower"}
+  }
+}, df)
+```
+
+Using Altair:
 
 ```python
 import altair
@@ -110,7 +127,7 @@ altair.Chart(cars).mark_point().encode(
     y='Miles_per_Gallon',
     color='Origin',
 )
-``` -->
+```
 
 To render a `.vg` or `.vl` (`.vg.json` and `.vl.json` are also supported) file as a tree, simply open it:
 

--- a/jupyterlab_vega/__init__.py
+++ b/jupyterlab_vega/__init__.py
@@ -1,4 +1,5 @@
 from IPython.display import display
+from .utils import prepare_spec
 
 
 # Running `npm run build` will create static resources in the static
@@ -32,7 +33,8 @@ def Vega(data):
     }
     display(bundle, raw=True)
 
-def VegaLite(data):
+def VegaLite(spec, data):
+    data = prepare_spec(spec, data)
     bundle = {
         'application/vnd.vegalite+json': data,
         'application/json': data,

--- a/jupyterlab_vega/utils.py
+++ b/jupyterlab_vega/utils.py
@@ -1,0 +1,99 @@
+import cgi
+import codecs
+import collections
+import os.path
+
+
+def nested_update(d, u):
+    """Update nested dictionary d (in-place) with keys from u."""
+    for k, v in u.items():
+        if isinstance(v, collections.Mapping):
+            d[k] = nested_update(d.get(k, {}), v)
+        else:
+            d[k] = v
+    return d
+
+
+def abs_path(path):
+    """Make path absolute."""
+    return os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        path)
+
+
+def get_content(path):
+    """Get content of file."""
+    with codecs.open(abs_path(path), encoding='utf-8') as f:
+        return f.read()
+
+
+def escape(string):
+    """Escape the string."""
+    return cgi.escape(string, quote=True)
+
+
+def sanitize_dataframe(df):
+    """Sanitize a DataFrame to prepare it for serialization.
+
+    * Make a copy
+    * Raise ValueError if it has a hierarchical index.
+    * Convert categoricals to strings.
+    * Convert np.int dtypes to Python int objects
+    * Convert floats to objects and replace NaNs by None.
+    * Convert DateTime dtypes into appropriate string representations
+    """
+    import pandas as pd
+    import numpy as np
+
+    df = df.copy()
+
+    if isinstance(df.index, pd.core.index.MultiIndex):
+        raise ValueError('Hierarchical indices not supported')
+    if isinstance(df.columns, pd.core.index.MultiIndex):
+        raise ValueError('Hierarchical indices not supported')
+
+    for col_name, dtype in df.dtypes.iteritems():
+        if str(dtype) == 'category':
+            # XXXX: work around bug in to_json for categorical types
+            # https://github.com/pydata/pandas/issues/10778
+            df[col_name] = df[col_name].astype(str)
+        elif np.issubdtype(dtype, np.integer):
+            # convert integers to objects; np.int is not JSON serializable
+            df[col_name] = df[col_name].astype(object)
+        elif np.issubdtype(dtype, np.floating):
+            # For floats, convert nan->None: np.float is not JSON serializable
+            col = df[col_name].astype(object)
+            df[col_name] = col.where(col.notnull(), None)
+        elif str(dtype).startswith('datetime'):
+            # Convert datetimes to strings
+            # astype(str) will choose the appropriate resolution
+            df[col_name] = df[col_name].astype(str).replace('NaT', '')
+    return df
+
+
+def prepare_spec(spec, data=None):
+    """Prepare a Vega-Lite spec for sending to the frontend.
+
+    This allows data to be passed in either as part of the spec
+    or separately. If separately, the data is assumed to be a
+    pandas DataFrame or object that can be converted to to a DataFrame.
+
+    Note that if data is not None, this modifies spec in-place
+    """
+    import pandas as pd
+
+    if isinstance(data, pd.DataFrame):
+        # We have to do the isinstance test first because we can't
+        # compare a DataFrame to None.
+        data = sanitize_dataframe(data)
+        spec['data'] = {'values': data.to_dict(orient='records')}
+    elif data is None:
+        # Data is either passed in spec or error
+        if 'data' not in spec:
+            raise ValueError('No data provided')
+    else:
+        # As a last resort try to pass the data to a DataFrame and use it
+        data = pd.DataFrame(data)
+        data = sanitize_dataframe(data)
+        spec['data'] = {'values': data.to_dict(orient='records')}
+    return spec

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ setup_args = dict(
     include_package_data = True,
     install_requires = [
         'jupyterlab>=0.11.0',
-        'ipython>=1.0.0'
+        'ipython>=1.0.0',
+        'pandas'
     ]
 )
 


### PR DESCRIPTION
Enable users to render DataFrames without depending on ipyvega or Altair:

```py
from jupyterlab_vega import VegaLite
import pandas as pd

df = pd.reada_json('cars.json')

VegaLite({
  "mark": "point",
  "encoding": {
    "y": {"type": "quantitative","field": "Acceleration"},
    "x": {"type": "quantitative","field": "Horsepower"}
  }
}, df)
```