### PR TITLE
update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,15 +135,7 @@ To render a `.vg` file as a tree, simply open it:
 
 ## Install
 
-```bash
-pip install jupyterlab_vega
-# For JupyterLab
-jupyter labextension install --symlink --py --sys-prefix jupyterlab_vega
-jupyter labextension enable --py --sys-prefix jupyterlab_vega
-# For Notebook
-jupyter nbextension install --symlink --py --sys-prefix jupyterlab_vega
-jupyter nbextension enable --py --sys-prefix jupyterlab_vega
-```
+You no longer need to install the jupyterlab_vega extension.  Just call ``altair.enable_mime_rendering()`` in your notebook.
 
 ## Development
 


### PR DESCRIPTION
Hopefully this will keep others from wasting time trying to figure out how to install this extension when they get the message:  ``JavaScript output is disabled in JupyterLab`` when trying to use Altair from jupyterlab.

closes #40 